### PR TITLE
Add canvas-based rendering with circle visualization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A terminal-based implementation of Conway's Game of Life written in Rust using the `ratatui` TUI framework. The application runs at 60 FPS with configurable simulation tick rates and supports interactive cell placement and pattern spawning.
+
+## Build and Run Commands
+
+```bash
+# Build the project
+cargo build
+
+# Run the application
+cargo run
+
+# Run with random pattern spawning
+cargo run -- --random
+cargo run -- -r
+
+# Show help
+cargo run -- --help
+```
+
+## Architecture
+
+### Core Components
+
+**State (`State` struct)** - Main application state containing:
+- `Grid`: 2D grid of cells stored as a flat `Vec<bool>` with wrapping indexing via `Index`/`IndexMut` traits
+- `Cursor`: Tracks user cursor position for interactive cell placement
+- `TickRate`: Controls simulation speed (Slow=1s, Normal=200ms, Fast=100ms)
+- `paused`: Boolean controlling whether simulation is running
+
+**Game Loop** (`State::run`)
+- Fixed 60 FPS rendering loop using frame accumulator pattern
+- Delta time-based tick accumulation for consistent simulation speed regardless of frame rate
+- Event handling via polling (non-blocking) to maintain smooth rendering
+
+**Grid Representation** (`Grid` struct)
+- Flat `Vec<bool>` with custom 2D indexing: `data[row * cols + col]`
+- Supports dynamic resizing on terminal resize events while preserving existing cells
+- Wrapping boundaries implemented using `rem_euclid` for toroidal topology
+
+**Patterns** (`Pattern` enum)
+- Predefined Conway's Life patterns: Glider, Blinker, Toad, Beacon, Pulsar, Lightweight Spaceship
+- Each pattern defined as `Vec<(usize, usize)>` of relative cell coordinates
+- Random spawning mode (`--random` flag) spawns patterns at 10% probability per tick
+
+### Game of Life Rules (implemented in `State::update`)
+
+Standard Conway's Life rules applied each tick:
+- Live cell with 2-3 neighbors survives
+- Dead cell with exactly 3 neighbors becomes alive
+- All other cells die or remain dead
+
+### Rendering (`Widget for &State`)
+
+Uses ratatui's Widget trait to render:
+- Live cells: white background space
+- Dead cells: empty space
+- Cursor position: asterisk (`*`) with inverted colors when over live cell
+
+## Key Implementation Details
+
+- **Event handling**: Arrow keys move cursor (with wrapping), spacebar toggles cell, `p` pauses, `[`/`]` adjust speed
+- **Terminal resize**: Grid dynamically resizes, preserving existing cells that fit in new dimensions
+- **Frame rate**: Locked to 60 FPS via `sleep()` to prevent excessive CPU usage
+- **Tick rate**: Simulation updates decoupled from frame rate using accumulator pattern

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,12 @@ use ratatui::{
   Terminal,
   buffer::Buffer,
   crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, poll, read},
-  layout::{Rect, Size},
+  layout::{Constraint, Direction, Layout, Rect, Size},
   prelude::CrosstermBackend,
-  style::{Color, Stylize},
-  text::{Line, Span, Text},
-  widgets::Widget,
+  style::{Color, Style},
+  symbols::Marker,
+  text::{Line, Span},
+  widgets::{Widget, canvas::{Canvas, Circle, Points}, Paragraph},
 };
 use std::{
   env::args,
@@ -22,10 +23,12 @@ const HELP: &str = "-help-
 controls:
   move cursor: arrow keys
   activate cell: spacebar
+  spawn random pattern: r
   change speed:
     slower = [
     faster = ]
   pause: p
+  clear grid: x
 flags:
   -r/--random: enable random activations
 control + c to exit";
@@ -74,6 +77,28 @@ impl State {
     }
   }
 
+  fn clear(&mut self) {
+    for i in 0..self.grid.data.len() {
+      self.grid.data[i] = false;
+    }
+  }
+
+  fn spawn_pattern_at_cursor(&mut self) {
+    let mut rng = rand::thread_rng();
+
+    let pattern = match rng.gen_range(0..6) {
+      0 => Pattern::Glider,
+      1 => Pattern::Blinker,
+      2 => Pattern::Toad,
+      3 => Pattern::Beacon,
+      4 => Pattern::Pulsar,
+      _ => Pattern::LightweightSpaceship,
+    };
+
+    // Place pattern centered at cursor position
+    self.place_pattern(pattern, self.cursor.row, self.cursor.col);
+  }
+
   fn run(&mut self, term: &mut Terminal<CrosstermBackend<Stdout>>, random: bool) -> Result<()> {
     let frame_rate = Duration::from_secs_f64(1. / 60.);
     let mut accumulator = Duration::ZERO;
@@ -99,7 +124,40 @@ impl State {
         }
       }
 
-      term.draw(|frame| frame.render_widget(&*self, frame.area()))?;
+      term.draw(|frame| {
+        let chunks = Layout::default()
+          .direction(Direction::Vertical)
+          .constraints([
+            Constraint::Min(0),
+            Constraint::Length(1),
+          ])
+          .split(frame.area());
+
+        frame.render_widget(&*self, chunks[0]);
+
+        // Render status bar
+        let status_line = Line::from(vec![
+          Span::raw(" "),
+          Span::styled("↑↓←→", Style::default().fg(Color::Cyan)),
+          Span::raw(" Move | "),
+          Span::styled("Space", Style::default().fg(Color::Green)),
+          Span::raw(" Toggle | "),
+          Span::styled("R", Style::default().fg(Color::Blue)),
+          Span::raw(" Random | "),
+          Span::styled("P", Style::default().fg(Color::Yellow)),
+          Span::raw(" Pause | "),
+          Span::styled("[ ]", Style::default().fg(Color::Magenta)),
+          Span::raw(" Speed | "),
+          Span::styled("X", Style::default().fg(Color::Red)),
+          Span::raw(" Clear | "),
+          Span::styled("Ctrl+C", Style::default().fg(Color::Gray)),
+          Span::raw(" Exit"),
+        ]);
+
+        let status_bar = Paragraph::new(status_line)
+          .style(Style::default().bg(Color::DarkGray));
+        frame.render_widget(status_bar, chunks[1]);
+      })?;
 
       let elapsed = last_frame.elapsed();
       if elapsed < frame_rate {
@@ -144,6 +202,8 @@ impl State {
             let alive = &mut self.grid[(*c_row, *c_col)];
             *alive = !*alive
           }
+          KeyCode::Char('x') => self.clear(),
+          KeyCode::Char('r') => self.spawn_pattern_at_cursor(),
           _ => {}
         }
       }
@@ -222,18 +282,65 @@ impl State {
 
 impl Widget for &State {
   fn render(self, area: Rect, buf: &mut Buffer) {
-    (0..self.grid.rows())
-      .map(|r| {
-        (0..self.grid.cols())
-          .map(|c| match self.grid[(r, c)] {
-            true if self.cursor.at(r, c) => Span::from("*").bg(Color::White).fg(Color::Black),
-            false if self.cursor.at(r, c) => Span::from("*"),
-            true => Span::from(" ").bg(Color::White),
-            false => Span::from(" "),
-          })
-          .collect::<Line>()
+    // Calculate cell size based on terminal dimensions
+    let cell_size = 2.0;
+    let x_bounds = [0.0, self.grid.cols() as f64 * cell_size];
+    let y_bounds = [0.0, self.grid.rows() as f64 * cell_size];
+
+    Canvas::default()
+      .marker(Marker::Dot)
+      .x_bounds(x_bounds)
+      .y_bounds(y_bounds)
+      .paint(|ctx| {
+        // Draw ALL cells - both alive and dead
+        for r in 0..self.grid.rows() {
+          for c in 0..self.grid.cols() {
+            let x = c as f64 * cell_size + cell_size / 2.0;
+            let y = (self.grid.rows() - 1 - r) as f64 * cell_size + cell_size / 2.0;
+            let is_cursor = self.cursor.at(r, c);
+            let is_alive = self.grid[(r, c)];
+
+            if is_alive {
+              // Draw filled circle for live cells
+              ctx.draw(&Circle {
+                x,
+                y,
+                radius: cell_size * 0.4,
+                color: if is_cursor {
+                  Color::Cyan  // Cursor on live cell
+                } else {
+                  Color::White  // Normal live cell
+                },
+              });
+            } else {
+              // Draw hollow circle outline for dead cells
+              let radius = cell_size * 0.35;
+              let num_points = 16; // Number of points to approximate circle
+              let color = if is_cursor {
+                Color::Yellow  // Cursor on dead cell
+              } else {
+                Color::DarkGray  // Normal dead cell outline
+              };
+
+              // Draw circle outline using points
+              let points: Vec<(f64, f64)> = (0..num_points)
+                .map(|i| {
+                  let angle = 2.0 * std::f64::consts::PI * i as f64 / num_points as f64;
+                  (
+                    x + radius * angle.cos(),
+                    y + radius * angle.sin(),
+                  )
+                })
+                .collect();
+
+              ctx.draw(&Points {
+                coords: &points,
+                color,
+              });
+            }
+          }
+        }
       })
-      .collect::<Text>()
       .render(area, buf);
   }
 }


### PR DESCRIPTION
- Replace text-based rendering with Canvas widget using Dot markers
- Add filled circles for live cells, hollow circles for dead cells
- Implement color-coded cursor highlighting
- Add keyboard shortcuts status bar at bottom
- Add 'r' key to spawn random patterns at cursor
- Add 'x' key to clear the canvas
- Update help text with new controls